### PR TITLE
Adding another profile item and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,8 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 2
+indent_style = tab
+indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+quote_type = single

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ node_modules
 
 # Massive Wiki Builder
 .massivewikibuilder/output/*
+
+# VSCode
+.vscode/*

--- a/map/Aram Zucker-Scharff.md
+++ b/map/Aram Zucker-Scharff.md
@@ -6,112 +6,130 @@ One of the [[People]].
 
 Updated profile, social links, how to pronounce my name, live at my <a href="https://aramzs.github.io/aramzs/" rel="me">Who Am I</a> page.
 
-[Latest info, major posts, and socials](https://aramzs.glitch.me/). 
+[Latest info, major posts, and socials](https://aramzs.glitch.me/).
 
-## My ideal thinking tool(s) 
+## My ideal thinking tool(s)
 
 TKTK
 
 ## My current tools and practices
 
 * I am bad at using email but I try to handle it using [[GTD]].
-* I sign up to every newsletter I encounter, then process it through custom code called Backreads to find significant links. 
-* I use [[Feedly]] as a feed reader. 
+* I sign up to every newsletter I encounter, then process it through custom code called Backreads to find significant links.
+* I use [[Feedly]] as a feed reader.
 * I mostly interact with Twitter through [[twitter list]]s.
-* All my note-taking happens in [[Obsidian]] and occasionally [[VSCode]]. 
-* I use [[PressForward]] to retain text archives of important links and reference material. I am one of the primary developers of this tool. 
-* I use [[11ty]] to generate context sites that I use to store, categorize and archive contextually-related blocks of information. 
-* I feed [[Instapaper]], [[Twitter]], and [[Mastodon]] into [[Pinboard]] for easy search and link finding. 
-* I use [[Instapaper]] to build an article-reading queue. 
-* I use [[GoodReads]] to build a book-reading queue.  
-* I use [[Letterboxd]] to build a movie-watching queue. 
-* I want something to build a TV-watching queue. 
-* I use [[Are.na]] for storing design ideas from other sites. 
+* All my note-taking happens in [[Obsidian]] and occasionally [[VSCode]].
+* I use [[PressForward]] to retain text archives of important links and reference material. I am one of the primary developers of this tool.
+* I use [[11ty]] to generate context sites that I use to store, categorize and archive contextually-related blocks of information.
+* I feed [[Instapaper]], [[Twitter]], and [[Mastodon]] into [[Pinboard]] for easy search and link finding.
+* I use [[Instapaper]] to build an article-reading queue.
+* I use [[GoodReads]] to build a book-reading queue.
+* I use [[Letterboxd]] to build a movie-watching queue.
+* I want something to build a TV-watching queue.
+* I use [[Are.na]] for storing design ideas from other sites.
 * I publish via [[WordPress]], [[11ty]], [[Substack]] and [[Jekyll]]
-* I use [[folder structure]] and [[tagging]] as techniques to keep my [[Obsidian]] notes organized. 
-* I use [[Dropbox]], [[git]], [[GitHub]], [[Obsidian]] mobile, and [[FolderSync]] to keep my notes synced between devices. 
-
+* I use [[folder structure]] and [[tagging]] as techniques to keep my [[Obsidian]] notes organized.
+* I use [[Dropbox]], [[git]], [[GitHub]], [[Obsidian]] mobile, and [[FolderSync]] to keep my notes synced between devices.
+* I use [[750Words]] for personal journalism
 
 ## Thinking Tool Ratings
 
 * [[Obsidian]]
-	* My current confidence with this tool: 9
-	* Openness: 6
-	* Note-making: 8
-	* Writing/Publishing: 4
-	* Idea discovery: 5
-	* User-friendliness: 6
-	* Power: 9
-	* Multiplayer: 1
-	* Help: 4
-	* Community: 7
-	* Cost: 9
-	* Data sovereignty: 10
+  * My current confidence with this tool: 9
+  * Openness: 6
+  * Note-making: 8
+  * Writing/Publishing: 4
+  * Idea discovery: 5
+  * User-friendliness: 6
+  * Power: 9
+  * Multiplayer: 1
+  * Help: 4
+  * Community: 7
+  * Cost: 9
+  * Data sovereignty: 10
 * [[PressForward]]
-	* My current confidence with this tool: 10
-	* Openness: 6
-	* Note-making: 4
-	* Writing/Publishing: 10
-	* Idea discovery: 9
-	* User-friendliness: 7
-	* Power: 9
-	* Multiplayer: 8
-	* Help: 4
-	* Community: 5
-	* Cost: 8
-	* Data sovereignty: 8
+  * My current confidence with this tool: 10
+  * Openness: 6
+  * Note-making: 4
+  * Writing/Publishing: 10
+  * Idea discovery: 9
+  * User-friendliness: 7
+  * Power: 9
+  * Multiplayer: 8
+  * Help: 4
+  * Community: 5
+  * Cost: 8
+  * Data sovereignty: 8
 * [[Pinboard]]
-	* My current confidence with this tool: 9
-	* Openness: 3
-	* Note-making: 2
-	* Writing/Publishing: 1
-	* Idea discovery: 8
-	* User-friendliness: 7
-	* Power: 5
-	* Multiplayer: 4
-	* Help: 2
-	* Community: 2
-	* Cost: 8
-	* Data sovereignty: 3
+  * My current confidence with this tool: 9
+  * Openness: 3
+  * Note-making: 2
+  * Writing/Publishing: 1
+  * Idea discovery: 8
+  * User-friendliness: 7
+  * Power: 5
+  * Multiplayer: 4
+  * Help: 2
+  * Community: 2
+  * Cost: 8
+  * Data sovereignty: 3
 * [[Instapaper]]
-	* My current confidence with this tool: 8
-	* Openness: 3
-	* Note-making: 2
-	* Writing/Publishing: 1
-	* Idea discovery: 3
-	* User-friendliness: 8
-	* Power: 4
-	* Multiplayer: 1
-	* Help: 2
-	* Community: 1
-	* Cost: 7
-	* Data sovereignty: 4
+  * My current confidence with this tool: 8
+  * Openness: 3
+  * Note-making: 2
+  * Writing/Publishing: 1
+  * Idea discovery: 3
+  * User-friendliness: 8
+  * Power: 4
+  * Multiplayer: 1
+  * Help: 2
+  * Community: 1
+  * Cost: 7
+  * Data sovereignty: 4
 * [[Are.na]]
-	* My current confidence with this tool: 7
-	* Openness: 3
-	* Note-making: 7
-	* Writing/Publishing: 3
-	* Idea discovery: 7
-	* User-friendliness: 6
-	* Power: 2
-	* Multiplayer: 6
-	* Help: 2
-	* Community: 2
-	* Cost: 9
-	* Data sovereignty: 1
+  * My current confidence with this tool: 7
+  * Openness: 3
+  * Note-making: 7
+  * Writing/Publishing: 3
+  * Idea discovery: 7
+  * User-friendliness: 6
+  * Power: 2
+  * Multiplayer: 6
+  * Help: 2
+  * Community: 2
+  * Cost: 9
+  * Data sovereignty: 1
 * [[Deepdwn]]
-	* My current confidence with this tool: 6
-	* Openness: 2
-	* Note-making: 8
-	* Writing/Publishing: 2
-	* Idea discovery: 6
-	* User-friendliness: 6
-	* Power: 7
-	* Multiplayer: 1
-	* Help: 4
-	* Community: 2
-	* Cost: 7
-	* Data sovereignty: 10
+  * My current confidence with this tool: 6
+  * Openness: 2
+  * Note-making: 8
+  * Writing/Publishing: 2
+  * Idea discovery: 6
+  * User-friendliness: 6
+  * Power: 7
+  * Multiplayer: 1
+  * Help: 4
+  * Community: 2
+  * Cost: 7
+  * Data sovereignty: 10
+* [[750Words]]
+  * My current confidence with this tool: 9
+  * Openness: 1
+  * Note-making: 6
+  * Writing/Publishing: 8
+  * Idea discovery: 5
+  * User-friendliness: 10
+  * Power: 3
+  * Multiplayer: 1
+  * Help: 2
+  * Community: 2
+  * Cost: 10
+  * Data sovereignty: 5
+
+
 ---
 
 ## Revision Notes
+
+20220215:
+* Added 750Words

--- a/map/Aram Zucker-Scharff.md
+++ b/map/Aram Zucker-Scharff.md
@@ -30,7 +30,7 @@ TKTK
 * I publish via [[WordPress]], [[11ty]], [[Substack]] and [[Jekyll]]
 * I use [[folder structure]] and [[tagging]] as techniques to keep my [[Obsidian]] notes organized.
 * I use [[Dropbox]], [[git]], [[GitHub]], [[Obsidian]] mobile, and [[FolderSync]] to keep my notes synced between devices.
-* I use [[750Words]] for personal journalism
+* I use [[750Words]] for personal journaling
 
 ## Thinking Tool Ratings
 

--- a/map/Aram Zucker-Scharff.md
+++ b/map/Aram Zucker-Scharff.md
@@ -29,103 +29,107 @@ TKTK
 * I use [[Are.na]] for storing design ideas from other sites.
 * I publish via [[WordPress]], [[11ty]], [[Substack]] and [[Jekyll]]
 * I use [[folder structure]] and [[tagging]] as techniques to keep my [[Obsidian]] notes organized.
+* I use keywords to add additional structure to my [[Obsidian]] notes.
+	* `up::`
+	* `down::`
+	* `tags:: #tagname`
+* I use [[YAML]] to add page aliases to leverage with wikilink-style links and to add additional metadata to my notes.
 * I use [[Dropbox]], [[git]], [[GitHub]], [[Obsidian]] mobile, and [[FolderSync]] to keep my notes synced between devices.
 * I use [[750Words]] for personal journaling
 
 ## Thinking Tool Ratings
 
 * [[Obsidian]]
-  * My current confidence with this tool: 9
-  * Openness: 6
-  * Note-making: 8
-  * Writing/Publishing: 4
-  * Idea discovery: 5
-  * User-friendliness: 6
-  * Power: 9
-  * Multiplayer: 1
-  * Help: 4
-  * Community: 7
-  * Cost: 9
-  * Data sovereignty: 10
+	* My current confidence with this tool: 9
+	* Openness: 6
+	* Note-making: 8
+	* Writing/Publishing: 4
+	* Idea discovery: 5
+	* User-friendliness: 6
+	* Power: 9
+	* Multiplayer: 1
+	* Help: 4
+	* Community: 7
+	* Cost: 9
+	* Data sovereignty: 10
 * [[PressForward]]
-  * My current confidence with this tool: 10
-  * Openness: 6
-  * Note-making: 4
-  * Writing/Publishing: 10
-  * Idea discovery: 9
-  * User-friendliness: 7
-  * Power: 9
-  * Multiplayer: 8
-  * Help: 4
-  * Community: 5
-  * Cost: 8
-  * Data sovereignty: 8
+	* My current confidence with this tool: 10
+	* Openness: 6
+	* Note-making: 4
+	* Writing/Publishing: 10
+	* Idea discovery: 9
+	* User-friendliness: 7
+	* Power: 9
+	* Multiplayer: 8
+	* Help: 4
+	* Community: 5
+	* Cost: 8
+	* Data sovereignty: 8
 * [[Pinboard]]
-  * My current confidence with this tool: 9
-  * Openness: 3
-  * Note-making: 2
-  * Writing/Publishing: 1
-  * Idea discovery: 8
-  * User-friendliness: 7
-  * Power: 5
-  * Multiplayer: 4
-  * Help: 2
-  * Community: 2
-  * Cost: 8
-  * Data sovereignty: 3
+	* My current confidence with this tool: 9
+	* Openness: 3
+	* Note-making: 2
+	* Writing/Publishing: 1
+	* Idea discovery: 8
+	* User-friendliness: 7
+	* Power: 5
+	* Multiplayer: 4
+	* Help: 2
+	* Community: 2
+	* Cost: 8
+	* Data sovereignty: 3
 * [[Instapaper]]
-  * My current confidence with this tool: 8
-  * Openness: 3
-  * Note-making: 2
-  * Writing/Publishing: 1
-  * Idea discovery: 3
-  * User-friendliness: 8
-  * Power: 4
-  * Multiplayer: 1
-  * Help: 2
-  * Community: 1
-  * Cost: 7
-  * Data sovereignty: 4
+	* My current confidence with this tool: 8
+	* Openness: 3
+	* Note-making: 2
+	* Writing/Publishing: 1
+	* Idea discovery: 3
+	* User-friendliness: 8
+	* Power: 4
+	* Multiplayer: 1
+	* Help: 2
+	* Community: 1
+	* Cost: 7
+	* Data sovereignty: 4
 * [[Are.na]]
-  * My current confidence with this tool: 7
-  * Openness: 3
-  * Note-making: 7
-  * Writing/Publishing: 3
-  * Idea discovery: 7
-  * User-friendliness: 6
-  * Power: 2
-  * Multiplayer: 6
-  * Help: 2
-  * Community: 2
-  * Cost: 9
-  * Data sovereignty: 1
+	* My current confidence with this tool: 7
+	* Openness: 3
+	* Note-making: 7
+	* Writing/Publishing: 3
+	* Idea discovery: 7
+	* User-friendliness: 6
+	* Power: 2
+	* Multiplayer: 6
+	* Help: 2
+	* Community: 2
+	* Cost: 9
+	* Data sovereignty: 1
 * [[Deepdwn]]
-  * My current confidence with this tool: 6
-  * Openness: 2
-  * Note-making: 8
-  * Writing/Publishing: 2
-  * Idea discovery: 6
-  * User-friendliness: 6
-  * Power: 7
-  * Multiplayer: 1
-  * Help: 4
-  * Community: 2
-  * Cost: 7
-  * Data sovereignty: 10
+	* My current confidence with this tool: 6
+	* Openness: 2
+	* Note-making: 8
+	* Writing/Publishing: 2
+	* Idea discovery: 6
+	* User-friendliness: 6
+	* Power: 7
+	* Multiplayer: 1
+	* Help: 4
+	* Community: 2
+	* Cost: 7
+	* Data sovereignty: 10
 * [[750Words]]
-  * My current confidence with this tool: 9
-  * Openness: 1
-  * Note-making: 6
-  * Writing/Publishing: 8
-  * Idea discovery: 5
-  * User-friendliness: 10
-  * Power: 3
-  * Multiplayer: 1
-  * Help: 2
-  * Community: 2
-  * Cost: 10
-  * Data sovereignty: 5
-
+	* My current confidence with this tool: 9
+	* Openness: 1
+	* Note-making: 6
+	* Writing/Publishing: 8
+	* Idea discovery: 5
+	* User-friendliness: 10
+	* Power: 3
+	* Multiplayer: 1
+	* Help: 2
+	* Community: 2
+	* Cost: 10
+	* Data sovereignty: 5
 
 ---
 


### PR DESCRIPTION
The `.editorconfig` file should allow contributors to have consistent editing experiences across tools and tool instances. Especially in regard to tabs. 