### PR TITLE
#3 - Preserve Markdown trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,8 @@ quote_type = single
 
 [*.md]
 trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2
 
 [*.{yaml,yml}]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,10 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
 quote_type = single
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
I was not aware that line-breaks were created with a double space at the end of a line. Very cool! Updated rules to preserve this technique. 

Figured I'd also get ahead of potential YAML use and add rules to preserve its requirements as well. 

Should resolve most of #3 